### PR TITLE
Fix file names in boot/tiddlywiki.files

### DIFF
--- a/src/plugins/danielo515/tiddlypouch/boot/tiddlywiki.files
+++ b/src/plugins/danielo515/tiddlypouch/boot/tiddlywiki.files
@@ -11,11 +11,11 @@
             }
         },
         {
-            "file": "./boot.css",
+            "file": "./boot.scss",
             "prefix":"<style>\n",
             "suffix":"\n</style>",
             "fields": {
-                "title": "$:/plugins/danielo515/tiddlypouch/boot.css",
+                "title": "$:/plugins/danielo515/tiddlypouch/boot.scss",
                 "tags":["$:/tags/RawMarkup"]
             }
         }

--- a/src/plugins/danielo515/tiddlypouch/databases/DbStore.js
+++ b/src/plugins/danielo515/tiddlypouch/databases/DbStore.js
@@ -157,9 +157,11 @@ module.exports = class DbStore {
                     if (err.name === 'conflict') { // check if it is a real conflict
                         self.logger.debug('O my gosh, update conflict!')
                         return self._db.get(document._id)
-                            .then(function (document) { //oops, we got a document, this was an actual conflict
-                                self.logger.log("A real update conflict!", document);
-                                throw err; // propagate the error for the moment
+                            .then(function (remoteDocument) { //oops, we got a document, this was an actual conflict
+				self.logger.log("A real update conflict!", document);
+				document._rev = remoteDocument._rev;
+				return self._db.put(document);
+                                //throw err; // propagate the error for the moment
                             })
                             .catch(function (err) {
                                 if (err.name === 'not_found') { // not found means no actual conflict


### PR DESCRIPTION
I was wanting to use tiddlypouch as a plugin for a nodejs version of TW. 

When using as a plugin under nodejs, `boot/tiddlywiki.files` lists `boot.css`, but the boot folder contains `boot.scss`. The NodeJS server refused to start because it couldn't find `boot.css`

The NodeJS booted and worked when I changed the filename.

Tiddlypouch works well under Tiddlywiki 5.1.19. NodeJS was the easiest way to bake tiddlypouch in. 