### PR TITLE
Handle 409 - immediate conflict

### DIFF
--- a/src/plugins/danielo515/tiddlypouch/databases/DbStore.js
+++ b/src/plugins/danielo515/tiddlypouch/databases/DbStore.js
@@ -157,9 +157,11 @@ module.exports = class DbStore {
                     if (err.name === 'conflict') { // check if it is a real conflict
                         self.logger.debug('O my gosh, update conflict!')
                         return self._db.get(document._id)
-                            .then(function (document) { //oops, we got a document, this was an actual conflict
-                                self.logger.log("A real update conflict!", document);
-                                throw err; // propagate the error for the moment
+                            .then(function (remoteDocument) { //oops, we got a document, this was an actual conflict
+				self.logger.log("A real update conflict!", document);
+				document._rev = remoteDocument._rev;
+				return self._db.put(document);
+                                //throw err; // propagate the error for the moment
                             })
                             .catch(function (err) {
                                 if (err.name === 'not_found') { // not found means no actual conflict


### PR DESCRIPTION
From `pouchdb.com/api.html`, `db.put()` will return 409 if document already exists. If a 409 is returned, then attempt the "update existing doc" approach from the pouchdb api.

