### PR TITLE
Dockerfile and scripts for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@
 #
 # Run these commands:
 # > docker build -t tiddlypouch-dev - < Dockerfile
-# > docker run --name tiddlypouch-dev -v ~/.gitconfig:/home/node/.gitconfig -v $PWD:/app -p 8087:8087 -it tiddlypouch-dev bash
+# > wget https://raw.githubusercontent.com/tkp1n/chromium-ci/master/seccomp/chromium.json
+# > docker run --security-opt seccomp=chromium.json --name tiddlypouch-dev -v ~/.gitconfig:/home/node/.gitconfig -v $PWD:/app -p 8087:8087 -it tiddlypouch-dev bash
 #
 # The last command should give you a shell inside a running container. Run these commands:
 # > yarn
@@ -14,14 +15,25 @@
 # If you need a separate shell in the same container, run
 # > docker exec -it tiddlypouch-dev bash
 
-FROM node:lts-alpine
+# The beginning of this Dockerfile was taken from
+# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+# Further enlightenment found on https://ndportmann.com/chrome-in-docker/
+FROM node:12-slim
 
-# Install packages needed to build and run
-RUN apk add build-base python
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends
+
 # Needed by scripts in package.json
-RUN apk add git
+RUN apt-get install -y git
+# Needed to run chrome (for puppeteer)
+RUN apt-get install -y libxtst6
 # Install that's nice to have
-RUN apk add bash curl
+RUN apt-get install -y bash curl
 
 VOLUME ["/app"]
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# This is the Dockerfile to get you up and running when working on tiddlypouch.
+# You do not need Docker, but if you have it, this should help setting things up.
+# If you do not use Docker, this file should give you hints at what you need to
+# install to get started.
+#
+# Run these commands:
+# > docker build -t tiddlypouch-dev - < Dockerfile
+# > docker run --name tiddlypouch-dev -v ~/.gitconfig:/home/node/.gitconfig -v $PWD:/app -p 8087:8087 -it tiddlypouch-dev bash
+#
+# The last command should give you a shell inside a running container. Run these commands:
+# > yarn
+# > yarn start.new
+#
+# If you need a separate shell in the same container, run
+# > docker exec -it tiddlypouch-dev bash
+
+FROM node:lts-alpine
+
+# Install packages needed to build and run
+RUN apk add build-base python
+# Needed by scripts in package.json
+RUN apk add git
+# Install that's nice to have
+RUN apk add bash curl
+
+VOLUME ["/app"]
+WORKDIR /app
+
+USER 1000

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "watch": "gulp watch",
         "bump": "gulp bump_version",
         "start": "npm run build && npm run TW",
+        "start.new": "npm run build && npm run TW.new",
         "TW": "nodemon ./node_modules/tiddlywiki/tiddlywiki.js ./wiki --verbose --server 8087 $:/core/save/all text/plain text/html",
+        "TW.new": "nodemon ./node_modules/tiddlywiki/tiddlywiki.js ./wiki --verbose --listen host=0.0.0.0 port=8087 root-tiddler=$:/core/save/all",
         "dev-docs": "tiddlywiki ./documentationwiki --verbose --server 8088 $:/core/save/all text/plain text/html"
     },
     "contributors": [


### PR DESCRIPTION
Hi there,

I wanted to see if I can work on tiddlypouch locally, so I set up a docker container with all the software needed for building and running it. I assume you are not using Docker for working on tiddlypouch, and that's totally fine with me.

The changes in this PR could make it easier for people to contribute in the future, even if they don't use Docker, because by looking at the Dockerfile they learn to some degree what they need to install (*). For contributers willing to work with Docker, this should make things significantly simpler. In general, using Docker in this way helps keep the host system clean from a particular project's requirements (with the exception of Docker, of course), which is really helpful when projects require conflicting versions of, say, nodejs.

(*) because I was lazy and installed a "meta package", this is not as detailed as it could be

There's a few things that aren't solved so far:

* The setup assumes the developer works as the unix user with uid 1000 outside of the container. Obviously not ideal, but fixable
* I needed to add two add two scripts in package.json to get the server to bind to 0.0.0.0, otherwise exposing the server to outside the Docker container does not work. I kept the existing scripts as they are.
* Not everything is set up for every situation -- testing requires a browser installed, and I did not bother with that yet

Before putting any more work into this, I would kindly ask if this setup, after being brought into a good shape, is a welcome contribution to the project.

One obvious risk of adding this is the added maintainence burden, in particular if the core developers do not use Docker.